### PR TITLE
Cargo.toml: Enable incremental builds in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,5 @@ winit = {version = "0.22.2", features = ["serde"]}
 opt-level = 1
 
 [profile.release]
+incremental = true
 lto = true


### PR DESCRIPTION
Brings rebuilds (incl. `cargo run --release`) down to 0.1s, from 4.5 minutes.

Doesn't need to be enabled for the debug builds (it is on by default there).

Many thanks to @eddyb for letting me know about this.